### PR TITLE
Windows fixes + README change

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,16 @@ lua require('code_runner').setup({})
 
 ### Options
 
--   `term`: configurations for the integrated terminal
+- `term`: configurations for the integrated terminal
 
-    Fields:
+  Fields:
 
-      - `position` - integrated terminal position(for option :h windows) default: `belowright`
+    - `position` - integrated terminal position(for option :h windows) default: `belowright`
+    - `size` - size of the terminal window (default: `8`)
 
-      - `size` - size of the terminal window (default: `8`)
+- `map`: keys to trigger execution (default: `<leader>r`)
 
--   `json_path`: absolute path to json file config (default: packer module path)
+- `json_path`: absolute path to json file config (default: packer module path)
 
 
 ### Setup
@@ -51,6 +52,7 @@ require('code_runner').setup {
     position = "vert",
     size = 8
   },
+  map = "<leader>r",
   json_path = "/home/myuser/.config/nvim/code_runner.json"
 }
 

--- a/lua/code_runner/options.lua
+++ b/lua/code_runner/options.lua
@@ -4,7 +4,7 @@ local options = {
         size = 8
       },
       map = "<leader>r",
-      json_path = os.getenv("HOME") .. '/.local/share/nvim/site/pack/packer/start/code_runner.nvim/lua/code_runner/code_runner.json'
+      json_path = vim.fn.stdpath("data") .. '/site/pack/packer/start/code_runner.nvim/lua/code_runner/code_runner.json'
 }
 
 local M = {}


### PR DESCRIPTION
Windows fix for [issue](https://github.com/CRAG666/code_runner.nvim/issues/2#issue-963406938) :
Windows doesn't have "HOME" dir, so used `vim.fnstdpatch("data")` to get directory where packer would be put.

README.md fix:
Added map to the example, so user is aware that they can change it, just incase `<leader>r` was already mapped to something before.