### PR TITLE
Apply consistent stylua formatting

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,6 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferDouble"
+no_call_parentheses = false

--- a/lua/code_runner.lua
+++ b/lua/code_runner.lua
@@ -5,19 +5,22 @@ local M = {}
 local loadTable = require("code_runner.load_json")
 M.setup = function(user_options)
   o.set(user_options)
-  vim.cmd [[lua require('code_runner').load_json_files()]]
-  vim.api.nvim_exec([[
+  vim.cmd([[lua require('code_runner').load_json_files()]])
+  vim.api.nvim_exec(
+    [[
   command! CRFiletype lua require('code_runner').open_filetype_suported()
   command! CRProjects lua require('code_runner').open_project_manager()
   command! RunCode lua require('code_runner').run_code()
   command! RunFile lua require('code_runner').run_filetype()
   command! RunProject lua require('code_runner').run_project()
-  ]], false)
+  ]],
+    false
+  )
   if o.get().filetype.map == o.get().project_context.map then
-    vim.api.nvim_set_keymap('n', o.get().filetype.map, ":RunCode<CR>", {noremap = true})
+    vim.api.nvim_set_keymap("n", o.get().filetype.map, ":RunCode<CR>", { noremap = true })
   else
-    vim.api.nvim_set_keymap('n', o.get().filetype.map, ":RunFile<CR>", {noremap = true})
-    vim.api.nvim_set_keymap('n', o.get().project_context.map, ":RunProject<CR>", {noremap = true})
+    vim.api.nvim_set_keymap("n", o.get().filetype.map, ":RunFile<CR>", { noremap = true })
+    vim.api.nvim_set_keymap("n", o.get().project_context.map, ":RunProject<CR>", { noremap = true })
   end
 end
 
@@ -31,12 +34,18 @@ M.load_json_files = function()
   end
 end
 
-M.run_code = function() commands.run() end
-M.run_filetype = function() commands.run_filetype() end
-M.run_project = function() commands.run_project() end
+M.run_code = function()
+  commands.run()
+end
+M.run_filetype = function()
+  commands.run_filetype()
+end
+M.run_project = function()
+  commands.run_project()
+end
 
 local function open_json(json_path)
-  local command ="tabnew " .. json_path
+  local command = "tabnew " .. json_path
   vim.cmd(command)
 end
 

--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -12,16 +12,15 @@ end --]]
 
 -- Create file modifiers
 local function filename_modifiers(path, modifiers)
-	if path == "%%" then
-		return path .. modifiers
-	end
-	return vim.fn.fnamemodify(path, modifiers)
+  if path == "%%" then
+    return path .. modifiers
+  end
+  return vim.fn.fnamemodify(path, modifiers)
 end
-
 
 -- Replace json variables with vim variables in command.
 -- If a command has no arguments, one is added with the current file path
-	--[[ local dir, fileName, ext = split_filename(path)
+--[[ local dir, fileName, ext = split_filename(path)
 	local vars_json = {
 		["%$fileNameWithoutExt"] = string.gsub(path, "." .. ext, ""),
 		["$fileName"] = fileName,
@@ -29,103 +28,101 @@ end
 		["$dir"] = dir
 	} --]]
 local function re_jsonvar_with_vimvar(command, path)
-	local no_sub_command = command
-	local vars_json = {
-		["%$fileNameWithoutExt"] = filename_modifiers(path, ":t:r"),
-		["$fileName"] = filename_modifiers(path, ":t"),
-		["$file"] = path,
-		["$dir"] = filename_modifiers(path, ":p:h")
-	}
-	for var, var_vim in pairs(vars_json) do
-		command = command:gsub(var, var_vim)
-	end
-	if command == no_sub_command then
-		if path == "%%" then path = "%" end
-		command = command .. " " .. path
-	end
-	return command
+  local no_sub_command = command
+  local vars_json = {
+    ["%$fileNameWithoutExt"] = filename_modifiers(path, ":t:r"),
+    ["$fileName"] = filename_modifiers(path, ":t"),
+    ["$file"] = path,
+    ["$dir"] = filename_modifiers(path, ":p:h"),
+  }
+  for var, var_vim in pairs(vars_json) do
+    command = command:gsub(var, var_vim)
+  end
+  if command == no_sub_command then
+    if path == "%%" then
+      path = "%"
+    end
+    command = command .. " " .. path
+  end
+  return command
 end
-
 
 -- Check if current buffer is in project
 -- if a project return table of project
 local function get_project_rootpath()
-	local path = "%:p:~:h"
-	local expand = ""
-	while expand ~= "~" do
-		expand = vim.fn.expand(path)
-		local project = vim.g.projectManager[expand]
-		if project then
-			project["path"] = expand
-			return project
-		end
-		path = path .. ":h"
-	end
-	return nil
+  local path = "%:p:~:h"
+  local expand = ""
+  while expand ~= "~" do
+    expand = vim.fn.expand(path)
+    local project = vim.g.projectManager[expand]
+    if project then
+      project["path"] = expand
+      return project
+    end
+    path = path .. ":h"
+  end
+  return nil
 end
-
 
 -- Return a command for filetype
 local function get_command(filetype, path)
-	local nvim_files = {
-		lua = "luafile %",
-		vim = "source %"
-	}
-	path = path or "%%"
-	local command = vim.g.fileCommands[filetype]
-	if command then
-		local command_vim = re_jsonvar_with_vimvar(command, path)
-		return prefix .. command_vim
-	end
-	return nvim_files[filetype]
+  local nvim_files = {
+    lua = "luafile %",
+    vim = "source %",
+  }
+  path = path or "%%"
+  local command = vim.g.fileCommands[filetype]
+  if command then
+    local command_vim = re_jsonvar_with_vimvar(command, path)
+    return prefix .. command_vim
+  end
+  return nvim_files[filetype]
 end
-
 
 -- Run command in project context
 local function run_project(context)
-		local command = ""
-		if context.file_name then
-			local file = context.path .. "/" .. context.file_name
-			if context.command then
-					command = prefix .. re_jsonvar_with_vimvar(context.command, file)
-			else
-					command = get_command(context.filetype, file)
-			end
-		else
-			command = prefix .. "cd " .. context.path .. context.command
-		end
-		vim.cmd(command)
+  local command = ""
+  if context.file_name then
+    local file = context.path .. "/" .. context.file_name
+    if context.command then
+      command = prefix .. re_jsonvar_with_vimvar(context.command, file)
+    else
+      command = get_command(context.filetype, file)
+    end
+  else
+    command = prefix .. "cd " .. context.path .. context.command
+  end
+  vim.cmd(command)
 end
-
 
 local M = {}
 
 -- Execute filetype or project
 function M.run()
-	local is_a_project = M.run_project()
-	if not is_a_project then
-		M.run_filetype()
-	end
+  local is_a_project = M.run_project()
+  if not is_a_project then
+    M.run_filetype()
+  end
 end
 
 -- Execute filetype
 function M.run_filetype()
-		local filetype = vim.bo.filetype
-		local command = get_command(filetype) or ""
-		vim.cmd(command)
+  local filetype = vim.bo.filetype
+  local command = get_command(filetype) or ""
+  vim.cmd(command)
 end
 
 -- Execute project
 function M.run_project()
-	local context = nil
-	if vim.g.projectManager then
-		context = get_project_rootpath()
-	end
-	if context then
-		run_project(context)
-		return true
-	end
-	return false
+  local context = nil
+  if vim.g.projectManager then
+    context = get_project_rootpath()
+  end
+  if context then
+    run_project(context)
+    return true
+  end
+  return false
 end
 
 return M

--- a/lua/code_runner/load_json.lua
+++ b/lua/code_runner/load_json.lua
@@ -1,19 +1,19 @@
 function LoadTable(json_path)
-    local contents = ""
-    local file = io.open( json_path, "r" )
+  local contents = ""
+  local file = io.open(json_path, "r")
 
-    if file then
-        -- read all contents of file into a string
-        contents = file:read( "*a" )
-        local status, result = pcall(vim.fn.json_decode, contents)
-        io.close( file )
-        if status then
-            return result
-        else
-            return nil
-        end
+  if file then
+    -- read all contents of file into a string
+    contents = file:read("*a")
+    local status, result = pcall(vim.fn.json_decode, contents)
+    io.close(file)
+    if status then
+      return result
+    else
+      return nil
     end
-    return nil
+  end
+  return nil
 end
 
 return LoadTable

--- a/lua/code_runner/options.lua
+++ b/lua/code_runner/options.lua
@@ -1,16 +1,17 @@
 local options = {
-      term = {
-        position = "belowright",
-        size = 8,
-      },
-      filetype = {
-        map = "<leader>r",
-        json_path = vim.fn.stdpath("data") .. '/site/pack/packer/start/code_runner.nvim/lua/code_runner/code_runner.json',
-      },
-      project_context = {
-        map = "<leader>r",
-        json_path = vim.fn.stdpath("data") .. '/site/pack/packer/start/code_runner.nvim/lua/code_runner/project_manager.json'
-      }
+  term = {
+    position = "belowright",
+    size = 8,
+  },
+  filetype = {
+    map = "<leader>r",
+    json_path = vim.fn.stdpath("data") .. "/site/pack/packer/start/code_runner.nvim/lua/code_runner/code_runner.json",
+  },
+  project_context = {
+    map = "<leader>r",
+    json_path = vim.fn.stdpath("data")
+      .. "/site/pack/packer/start/code_runner.nvim/lua/code_runner/project_manager.json",
+  },
 }
 
 local M = {}
@@ -23,6 +24,8 @@ M.set = function(user_options)
 end
 
 -- get user options
-M.get = function() return options end
+M.get = function()
+  return options
+end
 
 return M


### PR DESCRIPTION
I use null-ls to apply stylua automatically, Neoformat and other formatting plugins generally also support it. You can also manually run it with something like `stylua file` or `stylua **.lua`(which is what I did)

It is pretty opinionated but I set the config `.stylua.toml` closest to what I saw as the current style of the codebase. The main thing is `no_call_parentheses` and `quote_style`. But for both of these there was a mix on conventions across the codebase so I wasn't sure.

The main benefit is much more consistent indentation