### PR TITLE
RunCode with custome filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Your help is needed to make this plugin the best of its kind, be free to contrib
 
 -   `CRFiletype` - Open json  with supported files.
 -   `CRProjects` - Open json with list of projects.
--   `RunCode`    - Run the current project or file(Depending on whether the file belongs to a project or not)
+-   `:RunCode` - Runs based on file type, first checking if belongs to project, then if filetype mapping exists
+-   `:RunCode <A_key_here>` - Runs command with key of cool in the current directory.
 -   `RunFile`    - Run the current file
 -   `RunProject` - Run the current project(If you are in a project otherwise you will not do anything)
 

--- a/doc/code_runner.txt
+++ b/doc/code_runner.txt
@@ -27,8 +27,10 @@ code_runner.setup([{opts}])                                              *code_r
     Open json  with supported files.
 :CRProjects                                                             *:CRProjects*
     Open json with list of projects.
-:RunCode                                                                *:RunCode*
-    Run the current project or file.
+:RunCode {opt}                                                          *:RunCode*
+    Run the current project or file, if {opt} provided, it will run the
+    command that maps to that {opt} from the keys in the supported files
+    json
 :RunFile                                                                *:RunFile*
     Run the current file.
 :RunProject                                                             *:RunProject*

--- a/lua/code_runner.lua
+++ b/lua/code_runner.lua
@@ -18,9 +18,10 @@ M.setup = function(user_options)
     endfor
     return cmd_keys
   endfunction
+
   command! CRFiletype lua require('code_runner').open_filetype_suported()
   command! CRProjects lua require('code_runner').open_project_manager()
-  command! -nargs=? -complete=custom,CRunnerGetKeysForCmds RunCode lua require('code_runner').run_code()
+  command! -nargs=? -complete=custom,CRunnerGetKeysForCmds RunCode lua require('code_runner').run_code("<args>")
   command! RunFile lua require('code_runner').run_filetype()
   command! RunProject lua require('code_runner').run_project()
   ]],

--- a/lua/code_runner.lua
+++ b/lua/code_runner.lua
@@ -11,9 +11,16 @@ M.setup = function(user_options)
   vim.cmd([[lua require('code_runner').load_json_files()]])
   vim.api.nvim_exec(
     [[
+  function! CRunnerGetKeysForCmds(Arg,Cmd,Curs)
+    let cmd_keys = ""
+    for x in keys(g:fileCommands)
+      let cmd_keys = cmd_keys.x."\n"
+    endfor
+    return cmd_keys
+  endfunction
   command! CRFiletype lua require('code_runner').open_filetype_suported()
   command! CRProjects lua require('code_runner').open_project_manager()
-  command! RunCode lua require('code_runner').run_code()
+  command! -nargs=? -complete=custom,CRunnerGetKeysForCmds RunCode lua require('code_runner').run_code()
   command! RunFile lua require('code_runner').run_filetype()
   command! RunProject lua require('code_runner').run_project()
   ]],

--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -97,7 +97,17 @@ end
 local M = {}
 
 -- Execute filetype or project
-function M.run()
+function M.run(...)
+  if select('#',...) == 1 then
+    local json_key_select = select(1,...)
+    print(json_key_select)
+    -- since we have reached here, means we have our command key
+    local cmd_to_execute = get_command(json_key_select)
+    vim.cmd(cmd_to_execute)
+    return
+  end
+
+  --  procede here if no input arguments
   local is_a_project = M.run_project()
   if not is_a_project then
     M.run_filetype()

--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -100,7 +100,6 @@ local M = {}
 function M.run(...)
   if select('#',...) == 1 then
     local json_key_select = select(1,...)
-    print(json_key_select)
     -- since we have reached here, means we have our command key
     local cmd_to_execute = get_command(json_key_select)
     vim.cmd(cmd_to_execute)


### PR DESCRIPTION
Implemented option to allow user to pass custom filetype to :RunCode cmd.
EG: `:RunCode test` should run the command that maps to `test` instead of the filetype of the actual file.