### PR TITLE
Add support for toggleterm.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Fields:
 	- `tab`: Open code runner en new tab(default: false)
 	- `position`: Integrated terminal position(for option :h windows, default: `belowright`)
 	- `size`: Size of the terminal window (default: `8`)
+ 	- `toggleTerm`: Use toggleTerm (default: `false`)
 
 - `filetype_path`: Absolute path to json file config (default: packer module path, use absolute paths)
 

--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -95,6 +95,11 @@ local function execute(command, project_name_or_file)
 	local opt = o.get()
 	local bufname = "| :file ".. pattern .. project_name_or_file
 	close_runner(project_name_or_file)
+  if opt.term.toggleTerm then
+    local tcmd = string.format('TermExec cmd="%s"', command)
+    vim.cmd(tcmd)
+    return
+  end
 	if opt.term.tab then
 		vim.cmd("tabnew" .. opt.term.mode .. opt.prefix .. command)
 		vim.cmd(bufname)

--- a/lua/code_runner/options.lua
+++ b/lua/code_runner/options.lua
@@ -3,7 +3,8 @@ local options = {
 		tab = false,
 		mode = "",
 		position = "belowright",
-		size = 8
+		size = 8,
+    toggleTerm = false
 	},
 	filetype_path = vim.fn.stdpath("data") .. "/site/pack/packer/start/code_runner.nvim/lua/code_runner/code_runner.json",
 	filetype = {},


### PR DESCRIPTION
Add a simple feature in this plugin, using the toggleterm.nvim instead of native terminal.  currently, i tried moving to neovim from vscode, this plugin real help me a lot.:kissing_heart: