### PR TITLE
Default path can now have spaces

### DIFF
--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -21,7 +21,7 @@ local function jsonVars_to_vimVars(command, path)
   command = command:gsub("$dir", vim.fn.fnamemodify(path, ":p:h"))
 
   if command == no_sub_command then
-    command = command .. " " .. path
+    command = command .. " " .. path:gsub(" ", "\\ ")
   end
 
   return command


### PR DESCRIPTION
Fixed bug where not specifying a sub command would cause an error if the path contained a space