### PR TITLE
Fixed no sub commands not encoding filepath

### DIFF
--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -21,7 +21,8 @@ local function jsonVars_to_vimVars(command, path)
   command = command:gsub("$dir", vim.fn.fnamemodify(path, ":p:h"))
 
   if command == no_sub_command then
-    command = command .. " " .. path
+    command = command .. " $fileName"
+    command = command:gsub("$fileName", vim.fn.fnamemodify(path, ":t"))
   end
 
   return command


### PR DESCRIPTION
If a sub command is not provided in a command, gsub was not used, which meant paths weren't encoded. This has been fixed.