### PR TITLE
Allow multiple handlers for the same filetype

### DIFF
--- a/lua/code_runner.lua
+++ b/lua/code_runner.lua
@@ -32,7 +32,9 @@ local function open_json(json_path)
 end
 
 local function completion(ArgLead, options)
-  local filterd_args = vim.tbl_filter(function(v) return v:find(ArgLead:lower(), 1, true) == 1 end, options)
+  local filterd_args = vim.tbl_filter(function(v)
+    return v:find(ArgLead:lower(), 1, true) == 1
+  end, options)
   if not vim.tbl_isempty(filterd_args) then
     return filterd_args
   end
@@ -56,25 +58,31 @@ M.setup = function(user_options)
   local simple_cmds = {
     RunClose = commands.run_close,
     CRFiletype = M.open_filetype_suported,
-    CRProjects = M.open_project_manager
+    CRProjects = M.open_project_manager,
   }
   for cmd, func in pairs(simple_cmds) do
     vim.api.nvim_create_user_command(cmd, func, { nargs = 0 })
   end
 
   -- Commands with autocomplete
-  local modes = { 'float', 'tab', 'term', 'toggle', 'toggleterm', 'buf' }
+  local modes = { "float", "tab", "term", "toggle", "toggleterm", "buf" }
   -- Format:
   --  CoomandName = { function, option_list }
   local completion_cmds = {
     RunCode = { commands.run_code, vim.tbl_keys(o.get().filetype) },
     RunFile = { commands.run_filetype, modes },
-    RunProject = { commands.run_code, modes }
+    RunProject = { commands.run_code, modes },
   }
   for cmd, cmo in pairs(completion_cmds) do
-    vim.api.nvim_create_user_command(cmd, function(opts) cmo[1](opts.args) end, {
-      nargs = '?',
-      complete = function(ArgLead, ...)
+    vim.api.nvim_create_user_command(cmd, function(opts)
+      cmo[1](unpack(opts.fargs))
+    end, {
+      nargs = "*",
+      complete = function(ArgLead, word, ...)
+        -- only complete the first argument
+        if #vim.split(word, "%s+") > 2 then
+          return
+        end
         return completion(ArgLead, cmo[2])
       end,
     })

--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -16,6 +16,8 @@ local function jsonVars_to_vimVars(command, path, user_argument)
     end
   end
 
+  -- command is of type string
+
   local no_sub_command = command
 
   command = command:gsub("$fileNameWithoutExt", vim.fn.fnamemodify(path, ":t:r"))
@@ -225,6 +227,10 @@ function M.run_code(filetype, user_argument)
     local cmd_to_execute = get_command(filetype, nil, user_argument)
     if cmd_to_execute then
       run_mode(cmd_to_execute, vim.fn.expand("%:t:r"))
+  else
+      -- command was a lua function with no output
+      -- it already run
+      return
     end
   end
   --  procede here if no input arguments

--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -6,10 +6,9 @@ local pattern = "crunner_"
 -- @param command command to run the path
 -- @param path absolute path
 -- @return command with variables replaced by modifiers
-local function jsonVars_to_vimVars(command, path)
-
+local function jsonVars_to_vimVars(command, path, user_argument)
   if type(command) == "function" then
-    local cmd = command()
+    local cmd = command(user_argument)
     if type(cmd) == "string" then
       command = cmd
     else
@@ -52,12 +51,12 @@ end
 -- @param filetype filetype of path
 -- @param path absolute path to file
 -- @return command
-local function get_command(filetype, path)
+local function get_command(filetype, path, user_argument)
   local opt = o.get()
   path = path or vim.fn.expand("%:p")
   local command = opt.filetype[filetype]
   if command then
-    local command_vim = jsonVars_to_vimVars(command, path)
+    local command_vim = jsonVars_to_vimVars(command, path, user_argument)
     return command_vim
   end
   return nil
@@ -94,7 +93,7 @@ local function close_runner(bufname)
   end
 end
 
---- Execute comanda and create name buffer
+--- Execute command and create name buffer
 ---@param command string
 ---@param bufname string
 -- @param hide boolean
@@ -173,6 +172,14 @@ end
 
 local M = {}
 
+--- Run according to a mode
+---@param command string
+---@param bufname string
+---@param mode string
+function M.run_mode(command, bufname, mode)
+  run_mode(command, bufname, mode)
+end
+
 -- Get command for the current filetype
 function M.get_filetype_command()
   local filetype = vim.bo.filetype
@@ -212,10 +219,10 @@ function M.run_filetype(mode)
 end
 
 -- Execute filetype or project
-function M.run_code(filetype)
+function M.run_code(filetype, user_argument)
   if filetype ~= "" then
     -- since we have reached here, means we have our command key
-    local cmd_to_execute = get_command(filetype)
+    local cmd_to_execute = get_command(filetype, nil, user_argument)
     if cmd_to_execute then
       run_mode(cmd_to_execute, vim.fn.expand("%:t:r"))
     end


### PR DESCRIPTION
This pr add a custom user argument to `run_code` function, this allows users to specify multiple handlers for the same filetype using the specified argument as differentiator.

It also exposes `run_mode` so the user can benefit of this.

This is how I'm using it in deno, (one function for repl and one for running)
```lua
require('code_runner').setup({
    filetype = {
        typescript = function(arg)
            local filepath = vim.fn.expand("%:p")
            local commands = require("code_runner.commands")

            if not arg or arg == "run" then
                commands.run_mode("deno run -A --unstable " .. filepath, "deno run", "term")
            elseif arg == "repl" then
                commands.run_mode(
                    string.format(
                        [[deno repl --unstable --eval "import * as m from 'file:///%s';Object.entries(m).forEach(e=>window[e[0] ]=e[1])"]]
                        , filepath),
                    "repl",
                    "toggle"
                )
            end
        end,
        rust = "cargo r",
    },
})
vim.keymap.set('n', '<leader>x', function()
    local commands = require("code_runner.commands")
    local filetype = vim.api.nvim_exec("echo &filetype", true)
    commands.run_code(filetype, "run")
end, { noremap = true, silent = false })

vim.keymap.set('n', '<leader>r', function()
    local filename = vim.fn.expand("%:t")
    if filename:match("^crunner_repl") then
        vim.cmd("hide")
        return
    end
    local commands = require("code_runner.commands")
    local filetype = vim.api.nvim_exec("echo &filetype", true)

    commands.run_code(filetype, "repl")
end, { noremap = true, silent = false })
```
![rr](https://user-images.githubusercontent.com/22427111/188946303-1e79dc10-e7a3-4559-8f75-0c8510bb8172.gif)

