### PR TITLE
Addressing comment under #58

### DIFF
--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -155,6 +155,7 @@ local M = {}
 
 -- Valid modes
 M.modes = {
+  local opt = o.get()
   term = function(command, bufname)
     execute(command, bufname)
   end,

--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -155,7 +155,6 @@ local M = {}
 
 -- Valid modes
 M.modes = {
-  local opt = o.get()
   term = function(command, bufname)
     execute(command, bufname)
   end,
@@ -175,7 +174,6 @@ M.modes = {
   toggleterm = function(command, ...)
     local tcmd = string.format('TermExec cmd="%s"', command)
     vim.cmd(tcmd)
-    vim.cmd(opt.insert_prefix)
   end,
 }
 --- Run according to a mode


### PR DESCRIPTION
Hello,

First-time contributor (to _any_ project) and less-than-avid Lua user, here. This isn't the most sound bug fix, but the error is no longer showing for me. This PR is in response to a comment left under #58.

I removed line #177: ```vim.cmd(opt.insert_prefix)```. I'll try to explain my thought process so the maintainers can (possibly) help me understand why this is or is not an adequate solution.

My thinking here is as follows:

---
- **Q:** Does the error occur when using a different run method (float, term, etc.)?
- **A:** No. In other modes, no error occurs. 
---
- **Q:** What even is "opt?"
- **A:** Looking through the code, I see that  ```insert_prefix``` is set to ```""``` and then set to the value of ```startinsert``` elsewhere in the file. In the configuration settings and documentation, there is no mention of ```insert_prefix```. I'm not even really sure what it does (but again, I'm new to this). 
---
- **Q:** What other options did you try?
- **A:** I tried setting ```local opt = o.get()``` inside the ```M.modes{...}``` block to see if I was understanding Lua and the project correctly. That didn't work. 
---
- **Q:** So, how did you come to the conclusion that simply removing the line would work?
- **A:** I guessed! It's not apart of the user configuration, so it doesn't seem like it needs to be set. It's currently working for me. Again, please let me know how I can make this contribution better and any considerations I need to make going forward. 
 
Thank you for your time!