### PR TITLE
scroll term buffer to bottom so it will autoscroll

### DIFF
--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -118,6 +118,7 @@ local function execute(command, bufname, prefix)
     prefix = prefix .. " |"
   end
   vim.cmd(prefix .. " term " .. command)
+  vim.cmd("norm G")
   vim.opt_local.relativenumber = false
   vim.opt_local.number = false
   vim.cmd(set_bufname)


### PR DESCRIPTION
Currently if a command is run in a term buffer window, the window will not autoscroll to the bottom as the output grows. This fix allows it to automatically scroll. Thanks!