### PR TITLE
feat: detect filetype with nvim 0.8 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ When I was still in college it was common to try multiple programming languages,
 
 ### Requirements
 
-- Neovim (>= 0.7)
+- Neovim (>= 0.8)
+
+> **Note** 
+> If you are using Neovim neovim 0.7, you need to have `nvim-lua/plenary.nvim` installed
 
 ### Install
 
@@ -25,18 +28,18 @@ require("lazy").setup({
 - With [packer.nvim](https://github.com/wbthomason/packer.nvim)
 
 ```lua
-use { 'CRAG666/code_runner.nvim', requires = 'nvim-lua/plenary.nvim' }
+use 'CRAG666/code_runner.nvim'
+```
+
+- With [paq-nvim](https://github.com/savq/paq-nvim)
+
+```lua
+require "paq"{ 'CRAG666/code_runner.nvim'; }
 ```
 
 Consider using [CRAG666/betterTerm.nvim](https://github.com/CRAG666/betterTerm.nvim)
 
 require("harpoon.term").sendCommand(1, require("code_runner.commands").get_filetype_command() .. "\n")
-
-- With [paq-nvim](https://github.com/savq/paq-nvim)
-
-```lua
-require "paq"{'CRAG666/code_runner.nvim'; 'nvim-lua/plenary.nvim';}
-```
 
 ### Quick start
 

--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -79,9 +79,14 @@ local function get_project_command(context)
     if context.command then
       command = jsonVars_to_vimVars(context.command, file)
     else
-      local filetype = require("plenary.filetype")
-      local current_filetype = filetype.detect_from_extension(file)
-      command = get_command(current_filetype, file)
+      if vim.fn.has('nvim-0.8.0') == 1 then
+        local filetype = vim.filetype.match({ filename = file})
+        command = get_command(filetype, file)
+      else
+        local filetype = require("plenary.filetype")
+        local current_filetype = filetype.detect_from_extension(file)
+        command = get_command(current_filetype, file)
+      end
     end
   else
     command = "cd " .. context.path .. " &&" .. context.command


### PR DESCRIPTION
This new PR remove the dependency for `plenary.nvim` since is native in neovim 0.8. I've maintained the plenary code for retro compatibility with 0.7. But I you prefer supporting only 0.8, I can bump the neovim requirements in the README and remove the plenary code.