### PR TITLE
deprecate mode 'buffer'

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Don't use setup if filetype or a json path
 - Toggle runner
 - Reload runner
 - Run in a Float window
-- Run in a buffer
 - Run in a tab
 - Run in a split
 - Run in toggleTerm
@@ -86,8 +85,8 @@ All run commands allow restart. So, for example, if you use a command that does 
 
 - `:RunCode` - Runs based on file type, first checking if belongs to project, then if filetype mapping exists
 - `:RunCode <A_key_here>` - Execute command from its key in current directory.
-- `:RunFile <mode>` - Run the current file(optionally you can select an opening mode: {"toggle", "float", "tab", "toggleterm", "buf"}, default: "term").
-- `:RunProject <mode>` - Run the current project(If you are in a project otherwise you will not do anything, (optionally you can select an opening mode: {"toggle", "float", "tab", "toggleterm", "buf"}, default: "term").
+- `:RunFile <mode>` - Run the current file(optionally you can select an opening mode: {"toggle", "float", "tab", "toggleterm"}, default: "term").
+- `:RunProject <mode>` - Run the current project(If you are in a project otherwise you will not do anything, (optionally you can select an opening mode: {"toggle", "float", "tab", "toggleterm"}, default: "term").
 - `:RunClose` - Close runner
 - `:CRFiletype` - Open json with supported files(Use only if you configured with json files).
 - `:CRProjects` - Open json with list of projects(Use only if you configured with json files).
@@ -108,7 +107,7 @@ vim.keymap.set('n', '<leader>crp', ':CRProjects<CR>', { noremap = true, silent =
 
 ### Options
 
-- `mode`: Mode in which you want to run(default: term, valid options: {"toggle", "float", "tab", "toggleterm", "buf"}),
+- `mode`: Mode in which you want to run(default: term, valid options: {"toggle", "float", "tab", "toggleterm"}),
 - `focus`: Focus on runner window(only works on toggle, term and tab mode, default: true)
 - `startinsert`: init in insert mode(default: false)
 - `term`: Configurations for the integrated terminal
@@ -162,7 +161,7 @@ Note: A common mistake code runners make is using relative paths and not absolut
 
 ```lua
 require('code_runner').setup {
-  -- choose default mode (valid term, tab, float, toggle, buf)
+  -- choose default mode (valid term, tab, float, toggle)
   mode = 'term',
   -- Focus on runner window(only works on toggle, term and tab mode)
   focus = true,

--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -114,10 +114,8 @@ local function execute(command, bufname, prefix)
   local set_bufname = "file " .. bufname
   local current_wind_id = vim.api.nvim_get_current_win()
   close_runner(bufname)
-  if prefix ~= "bufdo" then
-    prefix = prefix .. " |"
-  end
-  vim.cmd(prefix .. " term " .. command)
+  vim.cmd(prefix)
+  vim.fn.termopen(command)
   vim.cmd("norm G")
   vim.opt_local.relativenumber = false
   vim.opt_local.number = false
@@ -169,9 +167,6 @@ M.modes = {
   end,
   tab = function(command, bufname)
     execute(command, bufname, "tabnew")
-  end,
-  buf = function(command, bufname)
-    execute(command, bufname, "bufdo")
   end,
   toggleterm = function(command, ...)
     local tcmd = string.format('TermExec cmd="%s"', command)


### PR DESCRIPTION
> **Note**  
> This is a preliminary PR for implement #55

Using a buffer for display output can be unstable and very buggy. Since it doesn't bring anything to the table compared to a regular terminal window, I think is safe to remove it. This PR will also move all code running to the `termopen` function that will make it possible to manage error from stderr, so you can have dignostics and quickfix. 