### PR TITLE
feat: ability to run projects in specific mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,37 +220,38 @@ It is important that you know that configuration is given priority in pure lua, 
 require('code_runner').setup {
   mode = "term",
   startinsert = true,
-	term = {
-		position = "vert",
-		size = 15,
-	},
-	filetype = {
+  term = {
+    position = "vert",
+    size = 15,
+  },
+  filetype = {
         java = {
           "cd $dir &&",
           "javac $fileName &&",
           "java $fileNameWithoutExt"
         },
-		python = "python3 -u",
-		typescript = "deno run",
+    python = "python3 -u",
+    typescript = "deno run",
         rust = {
           "cd $dir &&",
           "rustc $fileName &&",
           "$dir/$fileNameWithoutExt"
         },
-	},
-	project = {
-		["~/deno/example"] = {
-			name = "ExapleDeno",
-			description = "Project with deno using other command",
-			file_name = "http/main.ts",
-			command = "deno run --allow-net"
-		},
-		["~/cpp/example"] = {
-			name = "ExapleCpp",
-			description = "Project with make file",
-			command = "make buid && cd buid/ && ./compiled_file"
-		}
-	},
+  },
+  project = {
+    ["~/deno/example"] = {
+      name = "ExapleDeno",
+      description = "Project with deno using other command",
+      file_name = "http/main.ts",
+      command = "deno run --allow-net",
+      mode = "" -- valid: term, tab, float, toggle
+    },
+    ["~/cpp/example"] = {
+      name = "ExapleCpp",
+      description = "Project with make file",
+      command = "make buid && cd buid/ && ./compiled_file"
+    }
+  },
 }
 ```
 

--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -219,6 +219,7 @@ function M.get_project_command()
   if context then
     project_context.command = get_project_command(context) or ""
     project_context.name = context.name
+    project_context.mode = context.mode
     return project_context
   end
 end
@@ -250,6 +251,9 @@ function M.run_project(mode, notify)
   end
   local project = M.get_project_command()
   if project then
+    if not mode then
+      mode = project.mode
+    end
     run_mode(project.command, project.name, mode)
     return true
   end


### PR DESCRIPTION
This PR makes possible to specify a `mode` in which the project command can run. I'm mostly using the a split to run all my code. But I had this one time were I was building a TUI and I needed, only for that project to run the output on a float.

I've tested and the plugin behave like it should and it also has this new functionality.