### PR TITLE
Refactoring README for better readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ All run commands allow restart. So, for example, if you use a command that does 
 
 This plugin stopped creating mappings, in favor of you creating your own
 
-Recomended:
+Recommended:
 
 ```lua
 vim.keymap.set('n', '<leader>r', ':RunCode<CR>', { noremap = true, silent = false })
@@ -294,21 +294,21 @@ The file should look like this(the default file does not exist create it with th
 }
 ```
 
-if you want to add some other language or some other command follow this structure `key`: `commans`
+If you want to add some other language or some other command follow this structure `key`: `commans`
 
 #### Variables
 
 The available variables are the following:
 
-- `file` -- file path to currend file opened
-- `fileName` -- file name to curren file opened
-- `fileNameWithoutExt` -- file without extension file opened
-- `dir` -- path of directory to file opened
-- `end` -- finish the command (it is useful for commands that do not require final autocompletion)
+- `file`: path to current open file 
+- `fileName`: filename of current open file
+- `fileNameWithoutExt`: filename without extension of current file
+- `dir`: path to directory of current open file
+- `end`: finish the command (it is useful for commands that do not require final autocompletion)
 
 Below is an example of an absolute path and how it behaves depending on the variable:
 
-absolute path: `/home/anyuser/current/file.py`
+Absolute path: `/home/anyuser/current/file.py`
 
 - `file` = `/home/anyuser/current/file.py`
 - `fileName` = `file.py`
@@ -399,8 +399,8 @@ The file should look like this(the default file does not exist create it with th
 
 There are 3 main ways to configure the execution of a project (found in the example.)
 
-1. Use the default command defined in the filetypes file (see `:CRFiletype`or check your confi lua). In order to do that it is necessary to define file_name.
-2. Use a different command than the one set in `CRFiletype` or your config lua. In this case, the file_name and command must be provided.
+1. Use the default command defined in the filetypes file (see `:CRFiletype`or check your config). In order to do that it is necessary to define file_name.
+2. Use a different command than the one set in `CRFiletype` or your config. In this case, the file_name and command must be provided.
 3. Use a command to run the project. It is only necessary to define command(You do not need to write navigate to the root of the project, because automatically the plugin is located in the root of the project).
 
 Note: Don't forget to name your projects because if you don't do so code runner will fail as it uses the name for the buffer name
@@ -429,7 +429,7 @@ require("code_runner.commands").get_project_command() -- get the current command
 
 ## Harpoon
 
-you can directly integrate this plugin with [ThePrimeagen/harpoon](https://github.com/ThePrimeagen/harpoon) the way to do it is through command queries, harpoon allows the command to be sent to a terminal, below it is shown how to use harpoon term together with code_runner.nvim:
+You can directly integrate this plugin with [ThePrimeagen/harpoon](https://github.com/ThePrimeagen/harpoon) the way to do it is through command queries, harpoon allows the command to be sent to a terminal, below it is shown how to use harpoon term together with code_runner.nvim:
 
 ```lua
 require("harpoon.term").sendCommand(1, require("code_runner.commands").get_filetype_command() .. "\n")
@@ -437,7 +437,7 @@ require("harpoon.term").sendCommand(1, require("code_runner.commands").get_filet
 
 ## betterTerm
 
-you can directly integrate this plugin with [CRAG666/betterTerm.nvim](https://github.com/CRAG666/betterTerm.nvim) the way to do it is through command queries, `betterTerm` allows the command to be sent to a terminal, below it is shown how to use `betterTerm` term together with code_runner.nvim:
+You can directly integrate this plugin with [CRAG666/betterTerm.nvim](https://github.com/CRAG666/betterTerm.nvim) the way to do it is through command queries, `betterTerm` allows the command to be sent to a terminal, below it is shown how to use `betterTerm` term together with code_runner.nvim:
 
 ```lua
 
@@ -467,7 +467,7 @@ For unknown reasons, leaving a comma in the trailing element in any json file ca
 
 # Contributing
 
-Your help is needed to make this plugin the best of its kind, be free to contribute, criticize (don't be soft) or contribute ideas. All PR's are welcome.
+Your help is needed to make this plugin the best of its kind, be free to contribute, criticize (don't be soft) or contribute ideas. All PRs are welcome.
 
 > **Note**  
 > If you have any ideas to improve this project, do not hesitate to make a request, if problems arise, try to solve them and publish them. Don't be so picky I did this in one afternoon

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 <h4 align='center'>🔥 Code Runner for Neovim written in pure lua 🔥</h4>
 
-![Code Runner](https://i.ibb.co/1njTRTL/ezgif-com-video-to-gif.gif)
+<p align='center'><img src='https://i.ibb.co/1njTRTL/ezgif-com-video-to-gif.gif'></p>
 
-# Introduction
+## Introduction
 
 When I was still in college it was common to try multiple programming languages, at that time I used vscode that with a single plugin allowed me to run many programming languages, I left the ballast that are electron apps and switched to neovim, I searched the Internet and finally i found a lot of plugins, but none of them i liked (maybe i didn't search well), so i started adding autocmds like i don't have a tomorrow, this worked fine but this is lazy (maybe it will work for you, if you only programs in one or three languages maximum). So I decided to make this plugin and since the migration of my commands was very fast, it was just copy and paste and everything worked. Currently I don't test many languages anymore and work in the professional environment, but this plugin is still my swiss army knife.
 
-### Requirements
+## Requirements
 
 - Neovim (>= 0.8)
 
-### Install
+## Install
 
 - With [lazy.nvim](https://github.com/folke/lazy.nvim)
 
@@ -33,16 +33,38 @@ use 'CRAG666/code_runner.nvim'
 ```lua
 require "paq"{ 'CRAG666/code_runner.nvim'; }
 ```
-
 Consider using [CRAG666/betterTerm.nvim](https://github.com/CRAG666/betterTerm.nvim)
 
-### Quick start
+## Features
 
-Add the following line to your init.lua
+> **Note**  
+> If you want implement a new feature open an issue to know if it is worth implementing it and if there are people interested.
+
+- Toggle runner
+- Reload task on the fly
+- Run code in a Float window
+- Run code in a tab
+- Run code in a split
+- Run code with toggleTerm
+- Assign commands to projects without files in the root of the project
+- Run project commands in different modes for a per projects base
+
+## Setup
+
+This plugin can be configured either in lua, with the `setup` function, or with json files for interopability between this plugin and the [original code runner](https://github.com/formulahendry/vscode-code-runner) vscode plugin.
+
+See also:
+* [options](#options): options that can be passed to setup function;
+* [filetype](#setup-filetypes): filetype specific commands;
+* [project](#setup-projects): project specific commands.
+  * [project-parameters](#projects-parameters): project specific commands.
+
+### Minimal example
+
+#### Lua
 
 ```lua
 require('code_runner').setup({
-  -- put here the commands by filetype
   filetype = {
     java = {
       "cd $dir &&",
@@ -60,36 +82,38 @@ require('code_runner').setup({
 })
 ```
 
-Don't use setup if filetype or a json path
+#### Json
 
-#### Features
+> **Warning**  
+> A common mistake is using relative paths instead of absolute paths in . Use absolute paths in configurations or else the plugin won't work, in case you like to use short or relative paths you can use something like this `vim.fn.expand('~/.config/nvim/project_manager.json')`
 
-- Toggle runner
-- Reload runner
-- Run in a Float window
-- Run in a tab
-- Run in a split
-- Run in toggleTerm
+> **Note**
+> If you want to change were the code is displayed you need to specify the [`mode`]() attribute in the setup `function`
+
+```lua
+-- this is a config example
+require('code_runner').setup {
+  filetype_path = vim.fn.expand('~/.config/nvim/code_runner.json'),
+  project_path = vim.fn.expand('~/.config/nvim/project_manager.json')
+}
+```
+
+## Commands
 
 > **Note**  
-> If you want implement a new feature open an issue to know if it is worth implementing it and if there are people interested.
-
-### Functions
+> To check what modes ore supported see [mode parameter](#setup-1).
 
 All run commands allow restart. So, for example, if you use a command that does not have hot reload, you can call a command again and it will close the previous one and start again.
 
-- `:RunCode` - Runs based on file type, first checking if belongs to project, then if filetype mapping exists
-- `:RunCode <A_key_here>` - Execute command from its key in current directory.
-- `:RunFile <mode>` - Run the current file(optionally you can select an opening mode: {"toggle", "float", "tab", "toggleterm"}, default: "term").
-- `:RunProject <mode>` - Run the current project(If you are in a project otherwise you will not do anything, (optionally you can select an opening mode: {"toggle", "float", "tab", "toggleterm"}, default: "term").
-- `:RunClose` - Close runner
+- `:RunCode`: Runs based on file type, first checking if belongs to project, then if filetype mapping exists
+- `:RunCode <A_key_here>`: Execute command from its key in current directory.
+- `:RunFile <mode>`: Run the current file (optionally you can select an opening mode).
+- `:RunProject <mode>`: Run the current project(If you are in a project otherwise you will not do anything,).
+- `:RunClose`: Close runner
 - `:CRFiletype` - Open json with supported files(Use only if you configured with json files).
 - `:CRProjects` - Open json with list of projects(Use only if you configured with json files).
 
-This plugin stopped creating mappings, in favor of you creating your own
-
-Recommended:
-
+Recommended mappings:
 ```lua
 vim.keymap.set('n', '<leader>r', ':RunCode<CR>', { noremap = true, silent = false })
 vim.keymap.set('n', '<leader>rf', ':RunFile<CR>', { noremap = true, silent = false })
@@ -99,170 +123,54 @@ vim.keymap.set('n', '<leader>rc', ':RunClose<CR>', { noremap = true, silent = fa
 vim.keymap.set('n', '<leader>crf', ':CRFiletype<CR>', { noremap = true, silent = false })
 vim.keymap.set('n', '<leader>crp', ':CRProjects<CR>', { noremap = true, silent = false })
 ```
+### Variables
 
-### Options
+> **Note**  
+> If you don't want to use the plugin specific variables you can use vim [filename-modifiers](https://neovim.io/doc/user/cmdline.html#filename-modifiers).
 
-- `mode`: Mode in which you want to run(default: term, valid options: {"toggle", "float", "tab", "toggleterm"}),
-- `focus`: Focus on runner window(only works on toggle, term and tab mode, default: true)
-- `startinsert`: init in insert mode(default: false)
-- `term`: Configurations for the integrated terminal
-  Fields:
-  - `position`: Integrated terminal position(for option :h windows, default: `belowright`)
-  - `size`: Size of the terminal window (default: `8`)
-- `float`: Configurations for the float win
-  - `border`: Window border (see `:h nvim_open_win`)
-  - `height`
-  - `width`
-  - `x`
-  - `y`
-  - `border_hl`: (default: FloatBorder)
-  - `sybng_uy`: (qrshyg: "Abezny")
-  - `oyraq`: Genafcnerapl (frr `:u jvaoyraq`)
-- `before_run_filetype`: Execute before executing a file(type func)
-- `filetype_path`: Absolute path to json file config (default: "", use absolute paths)
-- `filetype`: If you prefer to use lua instead of json files, you can add your settings by file type here(type table)
-- `project_path`: Absolute path to json file config (default: "", use absolute paths)
-- `project`: If you prefer to use lua instead of json files, you can add your settings by project here(type table)
+This uses some special keyword to that means different things. This is do mainly for be compatible with the original vscode plugin.
 
-### Setup
+The available variables are the following:
+- `file`: path to current open file (e.g. `/home/user/current_dir/current_file.ext`
+- `fileName`: filename of current open file (e.g. `current_file.ext`)
+- `fileNameWithoutExt`: filename without extension of current file (e.g. `current_file`)
+- `dir`: path to directory of current open file (e.g. `/home/user/current_dir`)
+- `end`: finish the command (it is useful for commands that do not require final autocompletion)
+
+## Setup Filetypes
+
+> **Note**  
+> The commands are runned in a shell. This means that you can't run neovim commands with [this](https://github.com/CRAG666/code_runner.nvim/issues/59).
+
+### Lua
+
+The filetype table can take either a `string`, a `table` or a `function`.
 
 ```lua
--- this is a config example
-require('code_runner').setup {
-  mode = "tab",
-  focus = false,
-  startinsert = true,
-  term = {
-    position = "vert",
-    size = 8,
+-- in setup function
+filetype = {
+  java = { "cd $dir &&", "javac $fileName &&", "java $fileNameWithoutExt" },
+  python = "python3 -u",
+  typescript = "deno run",
+  rust = { "cd $dir &&",
+    "rustc $fileName &&",
+    "$dir/$fileNameWithoutExt"
   },
-  filetype_path = vim.fn.expand('~/.config/nvim/code_runner.json'),
-  project_path = vim.fn.expand('~/.config/nvim/project_manager.json')
-}
-```
-
-Note: A common mistake code runners make is using relative paths and not absolute ones. Use absolute paths in configurations or else the plugin won't work, in case you like to use short or relative paths you can use something like this `vim.fn.expand('~/.config/nvim/project_manager.json')`
-
-#### Default values
-
-```lua
-require('code_runner').setup {
-  -- choose default mode (valid term, tab, float, toggle)
-  mode = 'term',
-  -- Focus on runner window(only works on toggle, term and tab mode)
-  focus = true,
-  -- startinsert (see ':h inserting-ex')
-  startinsert = false,
-  term = {
-    --  Position to open the terminal, this option is ignored if mode is tab
-    position = "bot",
-    -- window size, this option is ignored if tab is true
-    size = 8,
-  },
-  float = {
-    -- Key that close the code_runner floating window
-    close_key = '<ESC>',
-    -- Window border (see ':h nvim_open_win')
-    border = "none",
-
-    -- Num from `0 - 1` for measurements
-    height = 0.8,
-    width = 0.8,
-    x = 0.5,
-    y = 0.5,
-
-    -- Highlight group for floating window/border (see ':h winhl')
-    border_hl = "FloatBorder",
-    float_hl = "Normal",
-
-    -- Transparency (see ':h winblend')
-    blend = 0,
-  },
-  filetype_path = "", -- No default path defined
-  before_run_filetype = function()
-    vim.cmd(":w")
+  cs = function(...)
+    local root_dir = require("lspconfig").util.root_pattern "*.csproj"(vim.loop.cwd())
+    return "cd " .. root_dir .. " && dotnet run$end"
   end,
-  filetype = {
-    javascript = "node",
-    java = {
-      "cd $dir &&",
-      "javac $fileName &&",
-      "java $fileNameWithoutExt"
-    },
-    c = {
-      "cd $dir &&",
-      "gcc $fileName",
-      "-o $fileNameWithoutExt &&",
-      "$dir/$fileNameWithoutExt"
-    },
-    cpp = {
-      "cd $dir &&",
-      "g++ $fileName",
-      "-o $fileNameWithoutExt &&",
-      "$dir/$fileNameWithoutExt"
-    },
-    python = "python -u",
-    sh = "bash",
-    rust = {
-      "cd $dir &&",
-      "rustc $fileName &&",
-      "$dir/$fileNameWithoutExt"
-    },
-  },
-  project_path = "", -- No default path defined
-  project = {},
-}
+},
 ```
 
-It is important that you know that configuration is given priority in pure lua, but if you prefer to configure in json, do not add the options filetype and project, and configure over the options filetype_path and project_path (these are paths of the os where your file is json), then you have a configuration in pure lua:
+If you want to add some other language or some other command follow this structure `key = commans`.
 
-```lua
-require('code_runner').setup {
-  mode = "term",
-  startinsert = true,
-  term = {
-    position = "vert",
-    size = 15,
-  },
-  filetype = {
-        java = {
-          "cd $dir &&",
-          "javac $fileName &&",
-          "java $fileNameWithoutExt"
-        },
-    python = "python3 -u",
-    typescript = "deno run",
-        rust = {
-          "cd $dir &&",
-          "rustc $fileName &&",
-          "$dir/$fileNameWithoutExt"
-        },
-  },
-  project = {
-    ["~/deno/example"] = {
-      name = "ExapleDeno",
-      description = "Project with deno using other command",
-      file_name = "http/main.ts",
-      command = "deno run --allow-net",
-      mode = "" -- valid: term, tab, float, toggle
-    },
-    ["~/cpp/example"] = {
-      name = "ExapleCpp",
-      description = "Project with make file",
-      command = "make buid && cd buid/ && ./compiled_file"
-    }
-  },
-}
-```
+### Json
 
-### Add support for more file types
+> **Note**  
+> In Json you can only pass the commands as a string
 
-#### Configure with json files
-
-Run `CRFiletype` , Open the configuration file.
-
-The file should look like this(the default file does not exist create it with the `CRFiletype` command):
-
+The equivalent for your json filetype file is:
 ```json
 {
   "java": "cd $dir && javac $fileName && java $fileNameWithoutExt",
@@ -272,84 +180,42 @@ The file should look like this(the default file does not exist create it with th
 }
 ```
 
-#### Configure with lua files
+If you want to add some other language or some other command follow this structure `key: commans`.
+
+## Setup Projects
+
+There are 3 main ways to configure the execution of a project (found in the example.)
+
+1. Use the default command defined in the filetypes file (see `:CRFiletype`or check your config). In order to do that it is necessary to define file_name.
+2. Use a different command than the one set in `CRFiletype` or your config. In this case, the file_name and command must be provided.
+3. Use a command to run the project. It is only necessary to define command (You do not need to write navigate to the root of the project, because automatically the plugin is located in the root of the project).
+
+Also see [project parameters](#projects) to set correctly your project commands.
+
+#### Lua
 
 ```lua
--- ..... more config .....
-  filetype = {
-    java = {
-      "cd $dir &&",
-      "javac $fileName &&",
-      "java $fileNameWithoutExt"
-    },
-  python = "python3 -u",
-  typescript = "deno run",
-    rust = {
-      "cd $dir &&",
-      "rustc $fileName &&",
-      "$dir/$fileNameWithoutExt"
-    },
+project = {
+  ["~/python/intel_2021_1"] = {
+    name = "Intel Course 2021",
+    description = "Simple python project",
+    file_name = "POO/main.py"
+  },
+  ["~/deno/example"] = {
+    name = "ExapleDeno",
+    description = "Project with deno using other command",
+    file_name = "http/main.ts",
+    command = "deno run --allow-net"
+  },
+  ["~/cpp/example"] = {
+    name = "ExapleCpp",
+    description = "Project with make file",
+    command = "make buid && cd buid/ && ./compiled_file"
+  }
 },
--- ..... more config .....
-}
 ```
 
-If you want to add some other language or some other command follow this structure `key`: `commans`
-
-#### Variables
-
-The available variables are the following:
-
-- `file`: path to current open file 
-- `fileName`: filename of current open file
-- `fileNameWithoutExt`: filename without extension of current file
-- `dir`: path to directory of current open file
-- `end`: finish the command (it is useful for commands that do not require final autocompletion)
-
-Below is an example of an absolute path and how it behaves depending on the variable:
-
-Absolute path: `/home/anyuser/current/file.py`
-
-- `file` = `/home/anyuser/current/file.py`
-- `fileName` = `file.py`
-- `fileNameWithoutExt` = `file`
-- `dir` = `/home/anyuser/current`
-
-Remember that if you don't want to use variables you can use vim [filename-modifiers](http://vimdoc.sourceforge.net/htmldoc/cmdline.html#filename-modifiers)
-
-##### Example
-
-Add support to javascript and objective c:
-
-json:
-
-```json
-{
-# ....... more ........
-  "javascript": "node",
-  "objective-c": "cd $dir && gcc -framework Cocoa $fileName -o $fileNameWithoutExt && $dir/$fileNameWithoutExt"
-}
-```
-
-lua:
-
-```lua
-{
--- ....... more ........
-    javascript = "node",
-  ["objective-c"] = "cd $dir && gcc -framework Cocoa $fileName -o $fileNameWithoutExt && $dir/$fileNameWithoutExt"
-}
-```
-
-In this example, there are two file types, one uses variables and the other does not. If no variables are used, the plugin adds the current file path. This is a way to add commands in a simple way for those languages that do not require complexity to execute (python and javascrip for example)
-
-### Add projects
-
-#### Configure with json files
-
-Run `CRProjects` , Open the project list.
-
-The file should look like this(the default file does not exist create it with the `CRProjects` command):
+#### Json
 
 ```json
 {
@@ -372,51 +238,49 @@ The file should look like this(the default file does not exist create it with th
 }
 ```
 
-#### Configure with lua files
+## Parameters
 
-```lua
--- ..... more config .....
-  project = {
-    ["~/python/intel_2021_1"] = {
-      name = "Intel Course 2021",
-      description = "Simple python project",
-      file_name = "POO/main.py"
-    },
-    ["~/deno/example"] = {
-      name = "ExapleDeno",
-      description = "Project with deno using other command",
-      file_name = "http/main.ts",
-      command = "deno run --allow-net"
-    },
-    ["~/cpp/example"] = {
-      name = "ExapleCpp",
-      description = "Project with make file",
-      command = "make buid && cd buid/ && ./compiled_file"
-    }
-},
--- ..... more config .....
-```
+### Setup
 
-There are 3 main ways to configure the execution of a project (found in the example.)
+This are the the configuration option you can pass to the `setup` function. To see the default values see: [`code_runner.nvim/lua/code_runner/options`](https://github.com/CRAG666/code_runner.nvim/blob/main/lua/code_runner/options.lua).
 
-1. Use the default command defined in the filetypes file (see `:CRFiletype`or check your config). In order to do that it is necessary to define file_name.
-2. Use a different command than the one set in `CRFiletype` or your config. In this case, the file_name and command must be provided.
-3. Use a command to run the project. It is only necessary to define command(You do not need to write navigate to the root of the project, because automatically the plugin is located in the root of the project).
+Parameters:
+- `mode`: Mode in which you want to run. Are supported: "toggle", "float", "tab", "toggleterm" (type: `bool`)
+- `focus`: Focus on runner window. Only works on toggle, term and tab mode (type: `bool`)
+- `startinsert`: init in insert mode (type: `bool`)
+- `term`: Configurations for the integrated terminal
+  - `position`: terminal position consult `:h windows` for options (type: `string`)
+  - `size`: Size of the terminal window (type: `uint` | `float`)
+- `float`: Configurations for the float win
+  - `border`: Window border see `:h nvim_open_win` (type: `string`)
+  - `height`
+  - `width`
+  - `x`
+  - `y`
+  - `border_hl`: (type: `string`)
+- `before_run_filetype`: Execute before executing a file (type: `func`)
+- `filetype`: If you prefer to use lua instead of json files, you can add your settings by file type here (type: `table`)
+- `filetype_path`: Absolute path to json file config (type: `absolute paths`)
+- `project`: If you prefer to use lua instead of json files, you can add your settings by project here (type: `table`)
+- `project_path`: Absolute path to json file config (type: `absolute paths`)
 
-Note: Don't forget to name your projects because if you don't do so code runner will fail as it uses the name for the buffer name
-
-#### Projects parameters
+### Projects
 
 > **Warning**  
 > Avoid using all the parameters at the same time. The correct way to use them is shown in the example and described above.
 
+> **Note**  
+> Don't forget to name your projects because if you don't do so code runner will fail as it uses the name for the buffer name
+
+Parameters:
 - `name`: Project name
 - `description`: Project description
 - `file_name`: Filename relative to root path
-- `command`: Command to run the project. It is possible to use variables exactly the same as we would in `CRFiletype`
+- `command`: Command to run the project. It is possible to use variables exactly the same as we would in [`CRFiletype`](#commands).
 
+## Integration with other plugins
 
-### Queries
+### API
 
 These functions could be useful if you intend to create plugins around code_runner, currently only the file type and current project commands can be accessed respectively
 
@@ -425,9 +289,7 @@ require("code_runner.commands").get_filetype_command() -- get the current comman
 require("code_runner.commands").get_project_command() -- get the current command for this project
 ```
 
-# Integration with other plugins
-
-## Harpoon
+### Harpoon
 
 You can directly integrate this plugin with [ThePrimeagen/harpoon](https://github.com/ThePrimeagen/harpoon) the way to do it is through command queries, harpoon allows the command to be sent to a terminal, below it is shown how to use harpoon term together with code_runner.nvim:
 
@@ -435,42 +297,34 @@ You can directly integrate this plugin with [ThePrimeagen/harpoon](https://githu
 require("harpoon.term").sendCommand(1, require("code_runner.commands").get_filetype_command() .. "\n")
 ```
 
-## betterTerm
+### betterTerm
 
 You can directly integrate this plugin with [CRAG666/betterTerm.nvim](https://github.com/CRAG666/betterTerm.nvim) the way to do it is through command queries, `betterTerm` allows the command to be sent to a terminal, below it is shown how to use `betterTerm` term together with code_runner.nvim:
 
 ```lua
-
 -- Send command to term one
 require("betterTerm").send(require("code_runner.commands").get_filetype_command(), 1)
 ```
 
-# Tip
-
-For unknown reasons, leaving a comma in the trailing element in any json file causes an error when loading into lua, so you have to remove the trailing comma in the last item.
-
-# Inspirations and thanks
+## Inspirations and thanks
 
 - The idea of this project comes from the vscode plugin [code_runner](https://marketplace.visualstudio.com/items?itemName=formulahendry.code-runner) You can even copy your configuration and pass it to this plugin, as they are the same in the way of defining commands associated with [filetypes](https://github.com/CRAG666/code_runner.nvim#add-support-for-more-file-types)
 - [jaq-nvim](https://github.com/is0n/jaq-nvim) some ideas of how to execute commands were taken from this plugin, thank you very much.
 - [FTerm.nvim](https://github.com/numToStr/FTerm.nvim) Much of how this README.md is structured was blatantly stolen from this plugin, thank you very much
-
 - Thanks to all current and future collaborators, without their contributions this plugin would not be what it is today
 
-# Screenshots
+## Screenshots
 
-![typescript](https://i.ibb.co/JCg3tNd/ezgif-com-video-to-gif.gif)
+<p align='center'><img src='https://i.ibb.co/JCg3tNd/ezgif-com-video-to-gif.gif'></p>
+<p align='center'><img src='https://i.ibb.co/1njTRTL/ezgif-com-video-to-gif.gif'></p>
+<p align='center'><img src='https://i.ibb.co/gFRhLgr/screen-1628272271.png'></p>
 
-![python](https://i.ibb.co/1njTRTL/ezgif-com-video-to-gif.gif)
-
-![Code_Runner](https://i.ibb.co/gFRhLgr/screen-1628272271.png "Code Runner with python")
-
-# Contributing
-
-Your help is needed to make this plugin the best of its kind, be free to contribute, criticize (don't be soft) or contribute ideas. All PRs are welcome.
+## Contributing
 
 > **Note**  
 > If you have any ideas to improve this project, do not hesitate to make a request, if problems arise, try to solve them and publish them. Don't be so picky I did this in one afternoon
+
+Your help is needed to make this plugin the best of its kind, be free to contribute, criticize (don't be soft) or contribute ideas. All PRs are welcome.
 
 # LICENCE
 


### PR DESCRIPTION
Hi,
This PR makes the following changes:
* Fix typos and Casing issues
* Center images
* Use hyperlinks to headings for better navigation
* Clear redundant examples
* Rethink the structure of the readme for better organisation.

Also I would like to know your thoughts on what documentation you will confident maintaining. At the moment we are using both README and vimdoc internal documentation, that seems to be very outdated and not useful. As I see it we can go with 3 different approaches:
1. Remove the vimdoc and maintain only the README;
2. Remove the documentation from the README and maintain only the vimdoc;
3. We maintain only the README and out generate the vimdoc, manually or automatically with pandoc.