### PR TITLE
Fix project patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ There are 3 main ways to configure the execution of a project (found in the exam
 2. Use a different command than the one set in `CRFiletype` or your config. In this case, the file_name and command must be provided.
 3. Use a command to run the project. It is only necessary to define command (You do not need to write navigate to the root of the project, because automatically the plugin is located in the root of the project).
 
+The key for each project is a pattern to match against the current filename of
+the buffer. The pattern is a lua [patterns](https://www.lua.org/pil/20.3.html)
+and needs to escape magic characters like `-`, `.`, `(`, etc. with a `%`.
+To match the entire path to a directory you cannot simply append `/`. This is
+due to `vim.fs.normalize` being used. Append `/.-` instead to prevent stripping
+of `/`.
+
 Also see [project parameters](#setup-projects) to set correctly your project commands.
 
 #### Lua
@@ -251,7 +258,12 @@ project = {
     name = "ExapleCpp",
     description = "Project with make file",
     command = "make buid && cd buid/ && ./compiled_file"
-  }
+  },
+  ["~/private/.*terraform%-prod.-/.-"] = {
+    name = "ExampleTerraform",
+    description = "All Folders in ~/private containing \"terraform-prod\"",
+    command = "terraform plan",
+  },
 },
 ```
 
@@ -274,6 +286,11 @@ project = {
     "name": "ExapleCpp",
     "description": "Project with make file",
     "command": "make buid && cd buid/ && ./compiled_file"
+  },
+  "~/private/.*terrafrom%-prod.-/.-": {
+    "name": "ExampleTerraform",
+    "description": "All Folders in ~/private containing \"terraform-prod\"",
+    "command": "terraform plan"
   }
 }
 ```

--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -38,13 +38,14 @@ end
 ---@return table?
 local function getProjectRootPath()
   local projects = o.get().project
-  local path = vim.fn.expand("%:p")
+  local file_path = vim.fn.expand("%:p")
   for project_path, _ in pairs(projects) do
     path_full = vim.fs.normalize(project_path)
-    if string.find(path, path_full) == 1 then
-      current_proyect = projects[project_path]
-      current_proyect["path"] = project_path
-      return current_proyect
+    local path_start, path_end = string.find(file_path, path_full)
+    if path_start == 1 then
+      current_project = projects[project_path]
+      current_project["path"] = string.sub(file_path, path_start, path_end)
+      return current_project
     end
   end
 end


### PR DESCRIPTION
Currently some project paths cannot be recognized because they contain
characters that the `string.find` function thinks are part of a pattern.
An example would be `/tmp/my-project` as it contains a `-` (non-greedy
match). Escaping the `-` with `%-` will result in an error when the
command wants to change the directory or wants to find a file in the
directory.

Minor change:
For clarity I renamed the variable `path` to `file_path` and fixed a
typo in `current_proyect` to `current_project`.

To allow for pattern matching in the keys of the table `project`,
`current_project.path` needs to be set to the match instead of the key
itself.

Due to the `vim.fs.normalize` that expands environment variables, `~`,
etc. the last `/` will be stripped from the pattern. This will lead to
potentially incomplete matches.
If your pattern is `.*terraform%-.-/` to match `/path/to/terrafrom-prod`
and `/path/to/terraform-dev`, your command will fail because the path
will yield only `/path/to/terraform-` thus not being able to find the
directory (eventhough the pattern tries to end with `/`).

To combat this — bit of a hack — you can append `.-` to retain the last
`/`.

The pattern then would be `.*terrafrom%-.-/.-`:
- `.*` greedily match everything
- `terraform` literal `terrafrom`
- `%-` matches `-` because it needs to be escaped with `%`
- `.-` non-greedily match everything
- `/` literal `/`
- `.-` matches nothing (since it is non-greedy) and is only there to
  prevent `/` from being stripped

Fixes #94