### PR TITLE
use "crunner" filetype on all crunner buffers

### DIFF
--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -123,6 +123,7 @@ local function execute(command, bufname, prefix)
     vim.opt_local.relativenumber = false
     vim.opt_local.number = false
     vim.cmd(set_bufname)
+    vim.api.nvim_buf_set_option(0, "filetype", "crunner")
     if prefix ~= "tabnew" then
       vim.bo.buflisted = false
     end


### PR DESCRIPTION
This facilitates the writing of custom autocommands by differentiating terminal buffers and code runner created buffers. Furthermore, the setting of the "crunner" filetype is implemented for code runner's floating windows, but not non-floating buffers. This change fixes that discrepancy. 