### PR TITLE
feat(default): Add ruby

### DIFF
--- a/lua/code_runner/options.lua
+++ b/lua/code_runner/options.lua
@@ -63,6 +63,7 @@ local options = {
     },
     python = "python -u",
     sh = "bash",
+    ruby = "ruby",
     rust = {
       "cd $dir &&",
       "rustc $fileName &&",


### PR DESCRIPTION
It's as simple as "ruby", so the maintenance code is almost zero. Ruby is a widely used language so it's worth adding to default.