### PR TITLE
fix warning when run by single file

### DIFF
--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -50,7 +50,7 @@ function M.run_code(filetype, user_argument)
   end
 
   -- Fallback to project or file type execution
-  local context = get_project():run(false)
+  local context = get_project():run(nil, false)
   if not context then
     get_filetype():run()
   end


### PR DESCRIPTION
fix unnecessary warnning when  run :RunCode with a single python file.
```python
#!/usr/bin/python3

print("hello world")

```
and the warnning is
```
:( There is no project associated with this path
```