### PR TITLE
better java default config and kotlin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,19 @@ require('code_runner').setup({
   filetype = {
     java = {
       "cd $dir &&",
+      'echo "-- compiling $fileName" &&',
       "javac $fileName &&",
-      "java $fileNameWithoutExt"
+      'echo "-- done " &&',
+      "for main in $( cat $fileName | pcregrep -M 'class.*{(.|\n)*public *static *void *main\\( *String *\\[\\] *args *\\) *\\{' | grep -o 'class *[a-zA-Z0-9]*' | sed -e 's/class *//g' ) ; do ; echo \"\n-- Running $main\n\" && java $main ; done",
+    },
+    kotlin = {
+      "cd $dir &&",
+      "echo compiling code &&",
+      "kotlinc $fileName &&",
+      "clear && echo cleaning up &&",
+      "rm -r META-INF &&",
+      "clear &&",
+      "kotlin \"$(echo $fileName | sed 's/.*/\\u&/' | sed 's/\\.\\s*\\([a-z]\\)/\\.\\u\\1/g' | sed 's/\\.//g' )\"",
     },
     python = "python3 -u",
     typescript = "deno run",
@@ -139,6 +150,7 @@ vim.keymap.set('n', '<leader>rc', ':RunClose<CR>', { noremap = true, silent = fa
 vim.keymap.set('n', '<leader>crf', ':CRFiletype<CR>', { noremap = true, silent = false })
 vim.keymap.set('n', '<leader>crp', ':CRProjects<CR>', { noremap = true, silent = false })
 ```
+
 lua functions:
 
 ```lua


### PR DESCRIPTION
# problem with java config

a better way of handling detecting class names which implements main method
in cases where file name is different than the classes that implements main method in java file
the plugin fails to run correct file
or if there are more than one class in a file which implements main method
than only the one which is named after the file is ran

# solution

using regex we dynamically run the class with main method

![Screenshot_20250525_153206](https://github.com/user-attachments/assets/2816ea68-f6d2-4686-a62f-c3bc720a7831)

as can be seen in above screenshot the file name is main yet the testing and text class are correctly executed

# Add kotlin runner config