### PR TITLE
fix #147 white-space  bug in by shellescape-ing all variable substitutions

### DIFF
--- a/lua/code_runner/commands.lua
+++ b/lua/code_runner/commands.lua
@@ -43,7 +43,8 @@ function M.run_code(filetype, user_argument)
     local cmd_to_execute = utils:getCommand(filetype)
     if cmd_to_execute then
       utils.opt.before_run_filetype()
-      utils:runMode(cmd_to_execute, vim.fn.expand("%:t:r"))
+      local filename = vim.fn.shellescape(vim.fn.expand("%:t:r"))
+      utils:runMode(cmd_to_execute, filename)
       return
     end
     return -- Exit if there is no valid command.

--- a/lua/code_runner/utils.lua
+++ b/lua/code_runner/utils.lua
@@ -45,7 +45,7 @@ function Utils:ctor(opt)
           "Vimux"
         )
       end
-    end
+    end,
   }
 end
 
@@ -69,15 +69,17 @@ function Utils:replaceVars(command, path)
   -- Check if we already have the result cached
   local cache_key = command .. ":" .. path
   local cached = var_cache[cache_key]
-  if cached then return cached end
+  if cached then
+    return cached
+  end
 
   local no_sub_command = command
 
   -- Pre-calculate replacement values to avoid multiple vim.fn calls
   local file_info = {
-    nameWithoutExt = vim.fn.fnamemodify(path, ":t:r"),
-    name = vim.fn.fnamemodify(path, ":t"),
-    dir = vim.fn.fnamemodify(path, ":p:h")
+    nameWithoutExt = vim.fn.shellescape(vim.fn.fnamemodify(path, ":t:r")),
+    name = vim.fn.shellescape(vim.fn.fnamemodify(path, ":t")),
+    dir = vim.fn.shellescape(vim.fn.fnamemodify(path, ":p:h")),
   }
 
   -- Use gsub once with a replacement function
@@ -87,7 +89,7 @@ function Utils:replaceVars(command, path)
     elseif var == "fileName" then
       return file_info.name
     elseif var == "file" then
-      return path
+      return vim.fn.shellescape(path)
     elseif var == "dir" then
       return file_info.dir
     elseif var == "end" then
@@ -98,7 +100,7 @@ function Utils:replaceVars(command, path)
   end)
 
   if command == no_sub_command then
-    command = command .. " " .. path
+    command = command .. " " .. vim.fn.shellescape(path)
   end
 
   -- Store result in cache


### PR DESCRIPTION
Aims to fix the issue #147

The root cause of the issue lies in the `lua/code_runner/utils.lua` file, where, the `replaceVars` function substitutes `$fileName`, `$file`, `$dir`, and `$fileNameWithoutExt` variables directly into the shell command string without quoting:

```lua
-- Current code (broken for paths with spaces)
local file_info = {
  nameWithoutExt = vim.fn.fnamemodify(path, ":t:r"),
  name = vim.fn.fnamemodify(path, ":t"),
  dir = vim.fn.fnamemodify(path, ":p:h")
}
```

When any of these values contains a space, the shell tokenises the resulting command incorrectly. The same issue affects the fallback path-append at the bottom of `replaceVars` when no `$var` substitution is matched.


### Major changes made

All file path values substituted into shell commands in `replaceVars` are now wrapped with `vim.fn.shellescape()`. This ensures paths containing spaces (or other shell-special characters) are treated as single arguments by the shell.

The issue was resolved by shellescape-ing variables, since functions like `vim.fn.shellescape()` is Neovim's built-in shell quoting function. It wraps the value in single quotes and escapes any single quotes within the value. 

**File:** `lua/code_runner/code_runner.lua` — `M.run_code` function

#### 1. Shellescape the bufname passed to `runMode`

```lua
-- BEFORE
utils:runMode(cmd_to_execute, vim.fn.expand("%:t:r"))

-- AFTER
local filename = vim.fn.shellescape(vim.fn.expand("%:t:r"))
utils:runMode(cmd_to_execute, filename)
```

This is where the path first enters the execution pipeline. `vim.fn.expand("%:t:r")` returns the raw filename stem (e.g. `my file`) with no quoting. The shell then splits it into separate tokens. Wrapping it with `vim.fn.shellescape()` before it is passed to `runMode` ensures it is treated as a single argument.


**File:** `lua/code_runner/utils.lua` — `replaceVars` function

#### 2. Quote `file_info` values

```lua
-- BEFORE
local file_info = {
  nameWithoutExt = vim.fn.fnamemodify(path, ":t:r"),
  name = vim.fn.fnamemodify(path, ":t"),
  dir = vim.fn.fnamemodify(path, ":p:h")
}

-- AFTER
local file_info = {
  nameWithoutExt = vim.fn.shellescape(vim.fn.fnamemodify(path, ":t:r")),
  name = vim.fn.shellescape(vim.fn.fnamemodify(path, ":t")),
  dir = vim.fn.shellescape(vim.fn.fnamemodify(path, ":p:h"))
}
```

#### 3. Quote `$file` substitution (raw `path` variable)

```lua
-- BEFORE
elseif var == "file" then
  return path

-- AFTER
elseif var == "file" then
  return vim.fn.shellescape(path)
```

#### 4. Quote fallback path append

```lua
-- BEFORE
if command == no_sub_command then
  command = command .. " " .. path
end

-- AFTER
if command == no_sub_command then
  command = command .. " " .. vim.fn.shellescape(path)
end
```

---

All in all, this fix covers all touch points across both files: the `runMode` call in `code_runner.lua`, and all four substitution points in `replaceVars` : `$fileNameWithoutExt`, `$fileName`, `$file`, `$dir`. 